### PR TITLE
Deploy to Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,8 +9,11 @@
   [headers.values]
     Content-Security-Policy = """
       default-src 'self';
+      child-src 'self' blob:;
+      img-src 'self' blob: data:;
+      script-src 'self' 'unsafe-inline';
       """
-    X-Frame-Options = "DENY"
+    X-Frame-Options = "SAMEORIGIN"
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "no-referrer"


### PR DESCRIPTION
## Overview

Creates a Netlify site to serve the static `website` directory.

Production DNS is set to https://texturemap.org and will take effect once this PR is merged.

## Testing Instructions

- Verify that the Netlify build passes.
- Go to https://deploy-preview-5--texturemap.netlify.app/ and confirm that the site loads with no console errors, including the demo map to the right of the page.
  - Mapbox may throw a warning about loading images, but this happens in local development as well and should be ignored while testing this PR.
- Confirm that there are no Content Security Policy errors.

Resolves #4 